### PR TITLE
Added disable APIs script

### DIFF
--- a/scripts/disable_apis.sh
+++ b/scripts/disable_apis.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Disable Service APIs in a GCP Project.
+
+PROJECT_ID=$1
+APIS="artifactregistry.googleapis.com cloudbuild.googleapis.com cloudresourcemanager.googleapis.com compute.googleapis.com domains.googleapis.com dns.googleapis.com iam.googleapis.com run.googleapis.com secretmanager.googleapis.com"
+
+echo "Executing script: $0"
+echo "GCP project: $PROJECT_ID"
+
+for API in $APIS
+do
+  echo "Disabling API: $API"
+  gcloud services disable "$API" --project "$PROJECT_ID"
+done


### PR DESCRIPTION
In this PR, a script was created to _disable APIs_ that are no longer relevant. 

Due to recent changes within development technologies, some services are no longer required, so they risk cluttering the environment.